### PR TITLE
Fix the go get install instruction

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ n 0.11.13
  Via go-get:
 
 ```
-$ go get github.com/visionmedia/stack
+$ go get github.com/visionmedia/stack/cmd/stack
 ```
 
  Via binaries:


### PR DESCRIPTION
This fixes the error "no buildable Go source files in ..." when one tries to
install stack using go get github.com/visionmedia/stack
